### PR TITLE
Add option to auto-reset to current player

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -10,6 +10,11 @@ function Vault:OnEnable()
 end
 
 function Vault:OnOpen()
+	-- Always reset to current character when interacting with a void storage NPC
+	if Bagnon:GetFrame('vault') then
+		Bagnon:GetFrame('vault'):SetPlayer(nil)
+	end
+
 	IsVoidStorageReady()
 	Bagnon.Cache.AtVault = true
 	Bagnon:ShowFrame('vault')


### PR DESCRIPTION
This is one of a four-part pull request (Bagnon, Bagnon_Config, Bagnon_VoidStorage, and Wildpants) that does the following:
1. Adds an option to automatically reset to the current player when closing and reopening any window.
2. Always resets the bank and void storage windows to the current player when clicking on a bank or void storage NPC.

See also:
- https://github.com/tullamods/Bagnon/pull/418
- https://github.com/tullamods/Bagnon_Config/pull/11
- https://github.com/tullamods/Wildpants/pull/3
