### PR TITLE
Soundkit adjustments for 7.3

### DIFF
--- a/components/dialogs.lua
+++ b/components/dialogs.lua
@@ -15,7 +15,7 @@ StaticPopupDialogs[ADDON .. 'VAULT_PURCHASE'] = {
 	button2 = NO,
 
 	OnAccept = function(self)
-		PlaySound('UI_Voidstorage_Unlock')
+		PlaySound(SOUNDKIT.UI_VOID_STORAGE_UNLOCK)
 		UnlockVoidStorage()
 	end,
 

--- a/components/frame.lua
+++ b/components/frame.lua
@@ -12,8 +12,8 @@ Frame.ItemFrame = Addon.VaultItemFrame
 Frame.MoneyFrame = Addon.TransferButton
 Frame.Bags = {'vault'}
 
-Frame.OpenSound = 'UI_EtherealWindow_Open'
-Frame.CloseSound = 'UI_EtherealWindow_Close'
+Frame.OpenSound = SOUNDKIT.UI_ETHEREAL_WINDOW_OPEN
+Frame.CloseSound = SOUNDKIT.UI_ETHEREAL_WINDOW_CLOSE
 Frame.MoneySpacing = 30
 Frame.BrokerSpacing = 2
 


### PR DESCRIPTION
Quick change over to the soundkit structure for 7.3; fixes showstopper that prevents the use of void storage. Tested in game, "works on my machine" disclaimer.